### PR TITLE
CRM-6008 Provide more configuration options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 */__pycache__
+*.sublime-*


### PR DESCRIPTION
This is the library that creates grouped logs in google cloud logs. We are moving various services (Credit Control, Gateway, Queues ect) into the services-bonline-testing project and these setting will allow us to keep the logs separate

New settings:
- GROUPED_LOGGING_GCP_PROJECT
- GROUPED_LOGGING_LOG_PREFIX